### PR TITLE
Refactor adaptiveSubs, add context management for reading/writing subtitles

### DIFF
--- a/morph/adaptiveSubs.py
+++ b/morph/adaptiveSubs.py
@@ -25,12 +25,12 @@ def run( inputSubsPath, outputSubsPath, morphemizer, matureFmt, knownFmt, unknow
     # Load files
     kdb = MorphDb( cfg1('path_known') )
     mdb = MorphDb( cfg1('path_mature') )
-    subFileLines = codecs.open( inputSubsPath, 'r', 'utf-8' ).readlines()
-
-    # Get dueling subs
-    dialogueLines = [ l for l in subFileLines if l.startswith( 'Dialogue' ) ]
-    header = subFileLines[ : subFileLines.index( dialogueLines[0] ) ]
-    assert len( dialogueLines ) % 2 == 0, 'Should be an even number of dialogue lines'
+    with codecs.open( inputSubsPath, 'r', 'utf-8' ) as subFile:
+	    subFileLines = subFile.readlines()
+	    # Get dueling subs
+	    dialogueLines = [ l for l in subFileLines if l.startswith( 'Dialogue' ) ]
+	    header = subFileLines[ : subFileLines.index( dialogueLines[0] ) ]
+	    assert len( dialogueLines ) % 2 == 0, 'Should be an even number of dialogue lines. Are you using duel subtitles?'
 
     lines = []
     for i in range( 0, len( dialogueLines ), 2 ):
@@ -50,7 +50,6 @@ def run( inputSubsPath, outputSubsPath, morphemizer, matureFmt, knownFmt, unknow
         else:
             lines.append( pre + unknownFmt % d )
 
-    outFile = codecs.open( outputSubsPath, 'w', 'utf-8' )
-    outFile.write( ''.join( header ) )
-    outFile.write( '\n'.join( lines ) )
-    outFile.close()
+    with codecs.open( outputSubsPath, 'w', 'utf-8' ) as outFile:
+	    outFile.write( ''.join( header ) )
+	    outFile.write( '\n'.join( lines ) )

--- a/morph/manager.py
+++ b/morph/manager.py
@@ -66,19 +66,19 @@ class AdaptiveSubWin( QDialog ):
         uFmt = str( self.unknownFmt.text() )
         morphemizer = getAllMorphemizers()[self.morphemizer.currentIndex()]
 
-        inputPath = QFileDialog.getOpenFileNames( None, 'Dueling subs to process', '', 'Subs (*.ass)' )[0]
-        if not inputPath: return
+        inputPaths = QFileDialog.getOpenFileNames( None, 'Dueling subs to process', '', 'Subs (*.ass)' )[0]
+        if not inputPaths: return
         outputPath = QFileDialog.getExistingDirectory( None, 'Save adaptive subs to')
         if not outputPath: return
 
         progWid, bar = getProgressWidget()   
         bar.setMinimum(0)
-        bar.setMaximum(len(inputPath))
+        bar.setMaximum(len(inputPaths))
         val = 0;  
-        for s in range(len(inputPath)):         
+        for fileNumber, subtitlePath in enumerate(inputPaths, start=1):         
             # MySubtitlesFolder/1 EpisodeSubtitles Episode 1.ass
-            outputSubsFileName = outputPath + "/" + str(s + 1) + " " + inputPath[s].split("/")[-1]
-            adaptiveSubs.run( inputPath[s], outputSubsFileName, morphemizer, mFmt, kFmt, uFmt )
+            outputSubsFileName = outputPath + "/" + str(fileNumber) + " " + subtitlePath.split("/")[-1]
+            adaptiveSubs.run( subtitlePath, outputSubsFileName, morphemizer, mFmt, kFmt, uFmt )
 
             val+=1;
             bar.setValue(val)


### PR DESCRIPTION
* Using `with` removes the need for us to manually manage resources ([context management](http://book.pythontips.com/en/latest/context_managers.html))
* Refactoring manager.py, particularly the adaptive subs `for` loop (good explanation [here](https://stackoverflow.com/a/24150815/10175127))  

Let me know if anything should be changed @landonepps