### PR TITLE
Add Review Now, Browse Morph features to browser, hide malfunctioning shortcuts, refactoring

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -45,6 +45,7 @@ def main():
     from .morph.browser import extractMorphemes
     from .morph.browser import batchPlay
     from .morph.browser import massTagger
+    from .morph.browser import reviewNow
     from .morph.browser import alreadyKnownTagger
     from .morph import newMorphHelper
     from .morph import stats

--- a/__init__.py
+++ b/__init__.py
@@ -45,7 +45,7 @@ def main():
     from .morph.browser import extractMorphemes
     from .morph.browser import batchPlay
     from .morph.browser import massTagger
-    from .morph.browser import reviewNow
+    from .morph.browser import learnNow
     from .morph.browser import alreadyKnownTagger
     from .morph import newMorphHelper
     from .morph import stats

--- a/__init__.py
+++ b/__init__.py
@@ -46,6 +46,7 @@ def main():
     from .morph.browser import batchPlay
     from .morph.browser import massTagger
     from .morph.browser import learnNow
+    from .morph.browser import browseMorph
     from .morph.browser import alreadyKnownTagger
     from .morph import newMorphHelper
     from .morph import stats

--- a/morph/browser/alreadyKnownTagger.py
+++ b/morph/browser/alreadyKnownTagger.py
@@ -4,11 +4,10 @@ from ..util import addBrowserNoteSelectionCmd, getFilter, jcfg
 from .. import util
 
 def pre( b ): # :: Browser -> State
-    return { 'tag':jcfg('Tag_AlreadyKnown') }
+    noteTotal = len(b.selectedNotes())
+    return { 'tag':jcfg('Tag_AlreadyKnown'), 'noteTotal':noteTotal }
 
 def per( st, n ): # :: State -> Note -> State
-    #n.delTag( st['tags'] ) # clear tags if they already exist?
-
     notecfg = getFilter(n)
     if notecfg is None: return st
     n.addTag(st['tag'])
@@ -16,7 +15,7 @@ def per( st, n ): # :: State -> Note -> State
     return st
 
 def post( st ): # :: State -> State
-    tooltip( _( 'Selected notes given the %s tag' % st['tag'] ) )
+    tooltip( _( '{} notes given the {} tag'.format(st['noteTotal'], st['tag']) ) )
     return st
 
-addBrowserNoteSelectionCmd( 'MorphMan: Already Known Tagger', pre, per, post, tooltip='Tag all selected cards as already known', shortcut=('K',) )
+addBrowserNoteSelectionCmd( 'MorphMan: Already Known Tagger', pre, per, post, tooltip='Tag all selected cards as already known', shortcut=("K",) )

--- a/morph/browser/batchPlay.py
+++ b/morph/browser/batchPlay.py
@@ -1,5 +1,5 @@
 #-*- coding: utf-8 -*-
-from ..util import addBrowserNoteSelectionCmd, cfg, cfg1
+from ..util import addBrowserNoteSelectionCmd, cfg
 import anki.sound
 import re
 
@@ -23,4 +23,4 @@ def post( st ):
     st['__reset'] = False
     return st
 
-addBrowserNoteSelectionCmd( 'MorphMan: Batch Play', pre, per, post, tooltip='Play all the videos for the selected cards', shortcut=('Ctrl+Alt+P',) )
+addBrowserNoteSelectionCmd( 'MorphMan: Batch Play', pre, per, post, tooltip='Play all the videos for the selected cards', shortcut=None )

--- a/morph/browser/browseMorph.py
+++ b/morph/browser/browseMorph.py
@@ -1,0 +1,31 @@
+#-*- coding: utf-8 -*-
+from aqt.utils import tooltip
+from ..util import addBrowserNoteSelectionCmd, infoMsg, jcfg
+from ..newMorphHelper import focus, focusName
+
+def pre( b ): return { 'focusMorph': [], 'b':b }
+
+def per( st, n ):
+    if n is None: return st
+    focusMorph = focus(n)
+    if focusMorph not in st['focusMorph']: # If a unique focus morph to search for
+        st['focusMorph'].append(focusMorph)
+    return st
+
+def post( st ):
+    search = ''
+    focusField = focusName()
+    focusArray = st['focusMorph']
+    for f in focusArray:
+        if f == focusArray[-1]: # If last morph in array, don't add "or"
+            search += '{}:{}'.format(focusField, f)
+        else:
+            search += '{}:{} or '.format(focusField, f)
+
+    if search != '':
+    	st['b'].form.searchEdit.lineEdit().setText(search)
+    	st['b'].onSearchActivated()
+    	tooltip( _( 'Browsing {} morphs'.format(len(st['focusMorph'])) ) )
+    return st
+
+addBrowserNoteSelectionCmd( 'MorphMan: Browse Morphs', pre, per, post, tooltip='Browse all notes containing the morphs from selected notes', shortcut=("L",) )

--- a/morph/browser/extractMorphemes.py
+++ b/morph/browser/extractMorphemes.py
@@ -6,7 +6,7 @@ from ..morphemizer import getMorphemizerByName
 from ..util import addBrowserNoteSelectionCmd, mw, getFilter, infoMsg, QFileDialog
 
 def pre( b ):
-    from .util import dbsPath # not defined until late, so don't import at top of module
+    from ..util import dbsPath # not defined until late, so don't import at top of module
     path = QFileDialog.getSaveFileName( caption='Save morpheme db to?', directory=dbsPath + os.sep + 'exportedMorphs.db' )
     if not path: return
     return { 'dbpath':str(path), 'morphDb':MorphDb() }
@@ -27,4 +27,4 @@ def post( st ):
     st['morphDb'].save( st['dbpath'] )
     infoMsg( 'DB saved with extracted morphemes' )
 
-addBrowserNoteSelectionCmd( 'MorphMan: Extract Morphemes', pre, per, post, tooltip='Extract morphemes in selected notes to a MorphMan db', shortcut=('Ctrl+Shift+E',) )
+addBrowserNoteSelectionCmd( 'MorphMan: Extract Morphemes', pre, per, post, tooltip='Extract morphemes in selected notes to a MorphMan db', shortcut=None )

--- a/morph/browser/learnNow.py
+++ b/morph/browser/learnNow.py
@@ -3,8 +3,7 @@ from aqt.utils import tooltip
 from aqt import browser
 from ..util import addBrowserCardSelectionCmd, mw, infoMsg
 
-def pre( b ):
-    return { 'cards':[], 'browser':b }
+def pre( b ): return { 'cards':[], 'browser':b }
 
 def per( st, c ):
     st['cards'].append( c )
@@ -15,7 +14,7 @@ def post( st ):
         mw.reviewer.cardQueue.append( c )
     st['browser'].close()
     infoMsg("") # Prevents an AttributeError directly above
-    tooltip( _( 'Immediately reviewing %d cards' % len(st['cards']) ) )
+    tooltip( _( 'Immediately reviewing {} cards'.format(len(st['cards'])) ) )
     return st
 
 addBrowserCardSelectionCmd( 'MorphMan: Learn Now', pre, per, post, tooltip='Immediately review the selected new cards', shortcut=None )

--- a/morph/browser/massTagger.py
+++ b/morph/browser/massTagger.py
@@ -28,12 +28,11 @@ def per( st, n ): # :: State -> Note -> State
             if m in st['db'].db:
                 n.addTag(st['tags'])
                 break
-
     n.flush()
     return st
 
 def post( st ): # :: State -> State
-    infoMsg( 'Successfully tagged notes containing morphemes in the selected db' )
+    tooltip(_( 'Successfully tagged notes containing morphemes in the selected db with "%s" ' % st['tags'] ) )
     return st
 
 addBrowserNoteSelectionCmd( 'MorphMan: Mass Tagger', pre, per, post, tooltip='Tag all cards that contain morphemes from db', shortcut=None )

--- a/morph/browser/massTagger.py
+++ b/morph/browser/massTagger.py
@@ -6,6 +6,7 @@ from ..util import addBrowserNoteSelectionCmd, getFilter, infoMsg, QInputDialog,
 from .. import util
 
 def pre( b ): # :: Browser -> State
+    noteCount = len(b.selectedNotes())
     tags, ok = QInputDialog.getText( b, 'Enter tags (e.x \"tag1 tag2\")', 'Tags', QLineEdit.Normal, 'hasMorph' )
     if not ok or not tags: return
 
@@ -15,9 +16,8 @@ def pre( b ): # :: Browser -> State
         infoMsg('The selected file was not a db file')
         return # per() and post() will still execute, but nothing happens
 
-
     db = MorphDb( path )
-    return { 'b':b, 'db':db, 'tags':str(tags) }
+    return { 'b':b, 'db':db, 'tags':str(tags), 'noteCount':noteCount }
 
 def per( st, n ): # :: State -> Note -> State
     notecfg = getFilter(n)
@@ -32,7 +32,7 @@ def per( st, n ): # :: State -> Note -> State
     return st
 
 def post( st ): # :: State -> State
-    tooltip(_( 'Successfully tagged notes containing morphemes in the selected db with "%s" ' % st['tags'] ) )
+    tooltip(_( 'Tagged {} notes containing morphemes in the selected db with "{}" '.format(st['noteCount'], st['tags']) ) )
     return st
 
 addBrowserNoteSelectionCmd( 'MorphMan: Mass Tagger', pre, per, post, tooltip='Tag all cards that contain morphemes from db', shortcut=None )

--- a/morph/browser/reviewNow.py
+++ b/morph/browser/reviewNow.py
@@ -1,0 +1,21 @@
+#-*- coding: utf-8 -*-
+from aqt.utils import tooltip
+from aqt import browser
+from ..util import addBrowserCardSelectionCmd, mw, infoMsg
+
+def pre( b ):
+    return { 'cards':[], 'browser':b }
+
+def per( st, c ):
+    st['cards'].append( c )
+    return st
+
+def post( st ):
+    for c in st['cards']:
+        mw.reviewer.cardQueue.append( c )
+    st['browser'].close()
+    infoMsg("") # Prevents an AttributeError directly above
+    tooltip( _( 'Immediately reviewing %d cards' % len(st['cards']) ) )
+    return st
+
+addBrowserCardSelectionCmd( 'MorphMan: Learn Now', pre, per, post, tooltip='Immediately review the selected new cards', shortcut=None )

--- a/morph/browser/viewMorphemes.py
+++ b/morph/browser/viewMorphemes.py
@@ -21,4 +21,4 @@ def post( st ):
     s = ms2str( st['morphemes'] )
     infoMsg( '----- All -----\n' + s )
 
-addBrowserNoteSelectionCmd( 'MorphMan: View Morphemes', pre, per, post, tooltip='View Morphemes for selected note', shortcut=('Ctrl+Shift+V',) )
+addBrowserNoteSelectionCmd( 'MorphMan: View Morphemes', pre, per, post, tooltip='View Morphemes for selected note', shortcut=None )

--- a/morph/newMorphHelper.py
+++ b/morph/newMorphHelper.py
@@ -175,28 +175,7 @@ def my_reviewer_shortcutKeys( self ):
 original_shortcutKeys = reviewer.Reviewer._shortcutKeys
 reviewer.Reviewer._shortcutKeys = my_reviewer_shortcutKeys
 
-########## 4 - immediately review selected cards
-# def pre( b ):
-#     ''' :type b: aqt.browser.Browser '''
-#     return { 'cards':[], 'browser':b }
-# def per( st, c ):
-#     st['cards'].append( c )
-#     return st
-# def post( st ):
-#     i = len(st['cards'])
-#     for c in st['cards']:
-#         mw.reviewer.cardQueue.append( c )
-
-#     # in special cases close() will already pop a new card from mw.reviewer.cardQueue
-#     st['browser'].close()
-#     tooltip( _( 'Immediately reviewing %d cards' % i ) )
-
-#     # only reset and fetch a new card if it wasn't already done with close()
-#     return {'__reset': len(mw.reviewer.cardQueue) == i}
-
-# addBrowserCardSelectionCmd( 'MorphMan: Learn Now', pre, per, post, tooltip='Immediately review the selected new cards', shortcut=('Ctrl+Shift+N',) )
-
-########## 5 - highlight morphemes using morphHighlight
+########## 4 - highlight morphemes using morphHighlight
 import re
 
 def isNoteSame(note, fieldDict):

--- a/morph/newMorphHelper.py
+++ b/morph/newMorphHelper.py
@@ -20,8 +20,8 @@ from . import main
 
 # config aliases
 def CN( n, key ):   return    cfg( n.mid, None, key )
-def focusName( n ): return    jcfg('Field_FocusMorph') # TODO remove argument n
-def focus( n ):     return n[ focusName(n) ]
+def focusName(): return    jcfg('Field_FocusMorph')
+def focus( n ):     return n[ focusName() ]
 
 
 ########## 6 parent deck pulls new cards from all children instead of sequentially (ie. mostly first)
@@ -49,7 +49,7 @@ def markFocusSeen( self, n ):
     global seenMorphs
     try:
         if not focus( n ): return
-        q = '%s:%s' % ( focusName( n ), focus( n ) )
+        q = '%s:%s' % ( focusName(), focus( n ) )
     except KeyError: return
     seenMorphs.add( focus(n) )
     numSkipped = len( self.mw.col.findNotes( q ) ) -1
@@ -156,7 +156,7 @@ def browseSameFocus( self ): #3
     try:
         n = self.card.note()
         if not focus( n ): return
-        q = '%s:%s' % ( focusName( n ), focus( n ) )
+        q = '%s:%s' % ( focusName(), focus( n ) )
         b = dialogs.open( 'Browser', self.mw )
         b.form.searchEdit.lineEdit().setText( q )
         b.onSearchActivated()

--- a/morph/util.py
+++ b/morph/util.py
@@ -10,10 +10,6 @@ from aqt import mw
 from aqt.utils import showCritical, showInfo, showWarning, tooltip
 from anki.hooks import addHook, wrap
 
-# only for jedi-auto-completion
-import aqt.main
-assert isinstance(mw, aqt.main.AnkiQt)
-
 ###############################################################################
 ## Global data
 ###############################################################################


### PR DESCRIPTION
The Review Now feature was commented out in newMorphHelper.py, and it was always on my radar to fix, so I did that tonight. Additionally, I hid all the shortcuts from the browser nav except the AlreadyKnown tagger shortcut, because for some reason none of the shortcuts work except "K." I'll be looking into that next (should be simple, just checking PyQt's documentation).

There's a line in reviewNow.py where I create a blank infoMsg, but when you actually press the "Learn Now" browser button, you barely see that infoMsg (it isn't really noticeable unless you know it should be there). For some reason, if that info message is not there, the following error is thrown:
```
Caught exception:
  File "aqt\progress.py", line 72, in handler
  File "aqt\browser.py", line 646, in <lambda>
  File "aqt\browser.py", line 660, in _onRowChanged
  File "aqt\editor.py", line 305, in setNote
  File "aqt\editor.py", line 333, in loadNote
<class 'AttributeError'>: 'NoneType' object has no attribute 'evalWithCallback'
```

I only found this becuase while debugging the code with `infoMsg('test1')` decorated all over the code to see what part of the code was causing the error, the feature would break after removing the infoMsg directly under the `.close()`. I don't know why, but I decided that it is not a big deal, since the feature itself works. If you know the issue, let me know @landonepps 

Another thing I did not know how to do is change the shortcut keys based on people's config.py. For example, if someone changed their AlreadyKnown button from K to something else in config, I wanted that to be what shows/works in the browser for them, but because of how alreadyKnownTagger.py and everything in the browser folder are setup, they execute right when anki starts, and so you can't grab user config since they haven't loaded a profile yet (an error msg pops up telling you exactly that. Let me know if you have a solution to this.