### PR TITLE
Fix shortcuts, allow shortcut customization in config

### DIFF
--- a/morph/browser/alreadyKnownTagger.py
+++ b/morph/browser/alreadyKnownTagger.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
 from aqt.utils import tooltip
-from ..util import addBrowserNoteSelectionCmd, getFilter, jcfg
+from anki.hooks import addHook
+from ..util import addBrowserNoteSelectionCmd, getFilter, jcfg, cfg1
 from .. import util
 
 def pre( b ): # :: Browser -> State
@@ -18,4 +19,10 @@ def post( st ): # :: State -> State
     tooltip( _( '{} notes given the {} tag'.format(st['noteTotal'], st['tag']) ) )
     return st
 
-addBrowserNoteSelectionCmd( 'MorphMan: Already Known Tagger', pre, per, post, tooltip='Tag all selected cards as already known', shortcut=("K",) )
+def runAlreadyKnownTagger():
+    label = 'MorphMan: Already Known Tagger'
+    tooltipMsg = 'Tag all selected cards as already known'
+    shortcut = cfg1('set known and skip key')
+    addBrowserNoteSelectionCmd( label, pre, per, post, tooltip=tooltipMsg, shortcut=(shortcut,) )
+
+addHook( 'profileLoaded', runAlreadyKnownTagger )

--- a/morph/browser/batchPlay.py
+++ b/morph/browser/batchPlay.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
-from ..util import addBrowserNoteSelectionCmd, cfg
 import anki.sound
+from anki.hooks import addHook
+from ..util import addBrowserNoteSelectionCmd, cfg, cfg1
 import re
 
 def pre( b ): return { 'vid2nid':{} }
@@ -23,4 +24,10 @@ def post( st ):
     st['__reset'] = False
     return st
 
-addBrowserNoteSelectionCmd( 'MorphMan: Batch Play', pre, per, post, tooltip='Play all the videos for the selected cards', shortcut=None )
+def runBatchPlay():
+    label = 'MorphMan: Batch Play'
+    tooltipMsg = 'Play all the videos for the selected cards'
+    shortcut = cfg1('set batch play key')
+    addBrowserNoteSelectionCmd( label, pre, per, post, tooltip=tooltipMsg, shortcut=(shortcut,) )
+
+addHook( 'profileLoaded', runBatchPlay )

--- a/morph/browser/browseMorph.py
+++ b/morph/browser/browseMorph.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
 from aqt.utils import tooltip
-from ..util import addBrowserNoteSelectionCmd, infoMsg, jcfg
+from anki.hooks import addHook
+from ..util import addBrowserNoteSelectionCmd, infoMsg, jcfg, cfg1
 from ..newMorphHelper import focus, focusName
 
 def pre( b ): return { 'focusMorph': [], 'b':b }
@@ -23,9 +24,15 @@ def post( st ):
             search += '{}:{} or '.format(focusField, f)
 
     if search != '':
-    	st['b'].form.searchEdit.lineEdit().setText(search)
-    	st['b'].onSearchActivated()
-    	tooltip( _( 'Browsing {} morphs'.format(len(st['focusMorph'])) ) )
+        st['b'].form.searchEdit.lineEdit().setText(search)
+        st['b'].onSearchActivated()
+        tooltip( _( 'Browsing {} morphs'.format(len(st['focusMorph'])) ) )
     return st
 
-addBrowserNoteSelectionCmd( 'MorphMan: Browse Morphs', pre, per, post, tooltip='Browse all notes containing the morphs from selected notes', shortcut=("L",) )
+def runBrowseMorph():
+    label = 'MorphMan: Browse Morphs'
+    tooltipMsg = 'Browse all notes containing the morphs from selected notes'
+    shortcut = cfg1('browse same focus key')
+    addBrowserNoteSelectionCmd( label, pre, per, post, tooltip=tooltipMsg, shortcut=(shortcut,) )
+
+addHook( 'profileLoaded', runBrowseMorph )

--- a/morph/browser/extractMorphemes.py
+++ b/morph/browser/extractMorphemes.py
@@ -1,9 +1,9 @@
 #-*- coding: utf-8 -*-
 import os
-
+from anki.hooks import addHook
 from ..morphemes import AnkiDeck, MorphDb, getMorphemes, ms2str
 from ..morphemizer import getMorphemizerByName
-from ..util import addBrowserNoteSelectionCmd, mw, getFilter, infoMsg, QFileDialog
+from ..util import addBrowserNoteSelectionCmd, mw, getFilter, infoMsg, QFileDialog, cfg1
 
 def pre( b ):
     from ..util import dbsPath # not defined until late, so don't import at top of module
@@ -27,4 +27,10 @@ def post( st ):
     st['morphDb'].save( st['dbpath'] )
     infoMsg( 'DB saved with extracted morphemes' )
 
-addBrowserNoteSelectionCmd( 'MorphMan: Extract Morphemes', pre, per, post, tooltip='Extract morphemes in selected notes to a MorphMan db', shortcut=None )
+def runExtractMorphemes():
+    label = 'MorphMan: Extract Morphemes'
+    tooltipMsg = 'Extract morphemes in selected notes to a MorphMan db'
+    shortcut = cfg1('set extract morphemes key')
+    addBrowserNoteSelectionCmd( label, pre, per, post, tooltip=tooltipMsg, shortcut=(shortcut,) )
+
+addHook( 'profileLoaded', runExtractMorphemes )

--- a/morph/browser/learnNow.py
+++ b/morph/browser/learnNow.py
@@ -1,7 +1,8 @@
 #-*- coding: utf-8 -*-
 from aqt.utils import tooltip
+from anki.hooks import addHook
 from aqt import browser
-from ..util import addBrowserCardSelectionCmd, mw, infoMsg
+from ..util import addBrowserCardSelectionCmd, mw, infoMsg, cfg1
 
 def pre( b ): return { 'cards':[], 'browser':b }
 
@@ -17,4 +18,10 @@ def post( st ):
     tooltip( _( 'Immediately reviewing {} cards'.format(len(st['cards'])) ) )
     return st
 
-addBrowserCardSelectionCmd( 'MorphMan: Learn Now', pre, per, post, tooltip='Immediately review the selected new cards', shortcut=None )
+def runLearnNow():
+    label = 'MorphMan: Learn Now'
+    tooltipMsg = 'Immediately review the selected new cards'
+    shortcut = cfg1('set learn now key')
+    addBrowserCardSelectionCmd( label, pre, per, post, tooltip=tooltipMsg, shortcut=(shortcut,) )
+
+addHook( 'profileLoaded', runLearnNow )

--- a/morph/browser/massTagger.py
+++ b/morph/browser/massTagger.py
@@ -1,8 +1,9 @@
 #-*- coding: utf-8 -*-
 from aqt.utils import tooltip
+from anki.hooks import addHook
 from ..morphemes import getMorphemes, MorphDb
 from ..morphemizer import getMorphemizerByName
-from ..util import addBrowserNoteSelectionCmd, getFilter, infoMsg, QInputDialog, QFileDialog, QLineEdit
+from ..util import addBrowserNoteSelectionCmd, getFilter, infoMsg, QInputDialog, QFileDialog, QLineEdit, cfg1
 from .. import util
 
 def pre( b ): # :: Browser -> State
@@ -35,4 +36,10 @@ def post( st ): # :: State -> State
     tooltip(_( 'Tagged {} notes containing morphemes in the selected db with "{}" '.format(st['noteCount'], st['tags']) ) )
     return st
 
-addBrowserNoteSelectionCmd( 'MorphMan: Mass Tagger', pre, per, post, tooltip='Tag all cards that contain morphemes from db', shortcut=None )
+def runBatchPlay():
+    label = 'MorphMan: Mass Tagger'
+    tooltipMsg = 'Tag all cards that contain morphemes from db'
+    shortcut = cfg1('set mass tagger key')
+    addBrowserNoteSelectionCmd( label, pre, per, post, tooltip=tooltipMsg, shortcut=(shortcut,) )
+
+addHook( 'profileLoaded', runBatchPlay )

--- a/morph/browser/viewMorphemes.py
+++ b/morph/browser/viewMorphemes.py
@@ -1,7 +1,8 @@
 #-*- coding: utf-8 -*-
+from anki.hooks import addHook
 from ..morphemes import getMorphemes, ms2str
 from ..morphemizer import getMorphemizerByName
-from ..util import addBrowserNoteSelectionCmd, getFilter, infoMsg
+from ..util import addBrowserNoteSelectionCmd, getFilter, infoMsg, cfg1
 
 def pre( b ): return { 'morphemes': [] }
 
@@ -21,4 +22,10 @@ def post( st ):
     s = ms2str( st['morphemes'] )
     infoMsg( '----- All -----\n' + s )
 
-addBrowserNoteSelectionCmd( 'MorphMan: View Morphemes', pre, per, post, tooltip='View Morphemes for selected note', shortcut=None )
+def runViewMorphemes():
+    label = 'MorphMan: View Morphemes'
+    tooltipMsg = 'View Morphemes for selected note'
+    shortcut = cfg1('set view morphemes key')
+    addBrowserNoteSelectionCmd( label, pre, per, post, tooltip=tooltipMsg, shortcut=(shortcut,) )
+
+addHook( 'profileLoaded', runViewMorphemes )

--- a/morph/config.py
+++ b/morph/config.py
@@ -22,6 +22,11 @@ default = {
         # reviewer mode keybindings
     'browse same focus key': 'l',
     'set known and skip key': 'k',
+    'set batch play key': 'Ctrl+Alt+P',
+    'set extract morphemes key': 'Ctrl+Alt+E',
+    'set learn now key': 'Ctrl+Alt+N',
+    'set mass tagger key': 'Ctrl+Alt+T',
+    'set view morphemes key': 'Ctrl+Alt+V',
     'auto skip alternatives': True,
     'print number of alternatives skipped': True,   # after answering or skipping a card in reviewer
 


### PR DESCRIPTION
This first "wraps" every browser button in a hook that runs after the profile is loaded. This way, the user config can be accessed, which not only allows the k/l shortcuts to be changed based on user preference, but also worked out as I tried fixing the shortcut keys for the other browser buttons. Now all the browser shortcuts work and all the buttons function except the Extract morphemes button due to what seems to be an outdated function. 