### PR TITLE
Addresses #23, add frequency list functionality

### DIFF
--- a/morph/config.py
+++ b/morph/config.py
@@ -7,6 +7,7 @@ default = {
     'path_dbs': os.path.join( mw.pm.profileFolder(), 'dbs' ),
     'path_priority': os.path.join( mw.pm.profileFolder(), 'dbs', 'priority.db' ),
     'path_ext': os.path.join( mw.pm.profileFolder(), 'dbs', 'external.db' ),
+    'path_frequency': os.path.join( mw.pm.profileFolder(), 'dbs', 'frequency.txt' ),
     'path_all': os.path.join( mw.pm.profileFolder(), 'dbs', 'all.db' ),
     'path_mature': os.path.join( mw.pm.profileFolder(), 'dbs', 'mature.db' ),
     'path_known': os.path.join( mw.pm.profileFolder(), 'dbs', 'known.db' ),
@@ -47,15 +48,25 @@ default = {
     # controls for morpheme analysis (only for japanese/mecab morphemizer)
     'japanese_tag': 'japanese',              # if a note has this tag, morphemes are be split with mecab, otherwise a space-based morphemizer is used
 
-        # try playing fields in this order when using batch media player
+    # try playing fields in this order when using batch media player
     'batch media fields': [ 'Video', 'Sound' ],
-        # configure morph man index algorithm
+
+    # configure morph man index algorithm
     'min good sentence length': 2,
     'max good sentence length': 8,          # +1000 MMI per morpheme outside the "good" length range
     'reinforce new vocab weight': 5.0,      # -reinforce_weight / maturity MMI per known that is not yet mature
     'verb bonus': 100,                      # -verb_bonus if at least one unknown is a verb
-    'priority.db weight': 200,              # -priority_weight per unknown that exists in priority.db
-        # lite update
+    
+    # -priority_weight per unknown that exists in priority.db
+    # Note: If priority.db weight > 999, it will only tag cards as "Priority" and have no effect on scheduling
+    'priority.db weight': 200,
+    
+    # Scale by which card "due" values decrease per unknown in frequency.txt
+    # Formula: weightScale * indexOfMorphemeOnFreqList / lengthOfFreqList (lower frequency -> higher due value -> card scheduled later)
+    # The lower the value from the above formula, the higher the "due" value
+    'frequency.txt weight scale': 700, 
+
+    # lite update
     'only update k+2 and below': False,     # this reduces how many notes are changed and thus sync burden by not updating notes that aren't as important
 
     # only these can have deck overrides

--- a/morph/preferencesDialog.py
+++ b/morph/preferencesDialog.py
@@ -125,6 +125,7 @@ class PreferencesDialog( QDialog ):
                 ("Priority:", 'Tag_Priority', 'Morpheme is in priority.db.'),
                 ("Too Short:", 'Tag_TooShort', 'Sentence is too short.'),
                 ("Too Long:", 'Tag_TooLong', 'Sentence is too long.'),
+                ("Frequency:", 'Tag_Frequency', 'Morpheme is in frequency.txt'),
             ]
         self.tagEntryList = []
         numberOfColumns = 2

--- a/morph/util.py
+++ b/morph/util.py
@@ -81,6 +81,7 @@ def jcfg_default():
         'Tag_Priority':'mm_priority',             # set if note contains an unknown that exists in priority.db
         'Tag_TooShort':'mm_tooShort',             # set if sentence is below optimal length range
         'Tag_TooLong':'mm_tooLong',               # set if sentence is above optimal length range
+        'Tag_Frequency': 'mm_frequency',          # set if sentence is above optimal length range
 
         # filter for cards that should be analyzed, higher entries have higher priority
         'Filter': [


### PR DESCRIPTION
Related to #23:
I previously did not fully understand how databases were being serialized. Since the priority.db makes it difficult to implement this feature, I created this implementation to allow users to put their frequency lists into morphman (as a txt file) and have the scheduling of their cards be changed based on the frequency of morphemes that exist both in a card and on the user's frequency.txt.

Explanations of the implementation:
1. Users rename their frequency list to frequency.txt and place it into their dbs folder (users are used to messing only with that folder whether it's for priority/external/extractedMorph.dbs anyway so it makes sense that it goes there I believe). 
2. In main.py, the txt file is "imported" into a list which is used throughout the recalc process
3. I attached the written-out formula for calculating how the dues of cards are affected based on the frequency of the word. It's a simple proportionality statement, where on the left is the index of the word over the length of the list, and the right has x divided by the scale. Essentially, regardless of the scale, the larger the index (meaning the less frequent the word), the larger the due becomes. If you make the scale too big, then you risk making words that are relatively frequent (say index 100 on the frequency list) not have any affect on scheduling - this is because if that usefulness calculation in main.py exceeds 999, then the card is no different than any other normal card. So the scale of 700 works really well with frequency lists of any size. (Note I could have just left the "usefulness" part of the calculation just for priority.db and have something separate for frequency.txt, but figured that it ultimately does not matter as long as cards are ordered correctly, so I just used that same variable and made it unlikely for people to pass 999, even if they set their priority.db weight really high in their config).

![IMG-7758](https://user-images.githubusercontent.com/40217167/60643854-490c6280-9de9-11e9-9331-a523691ccb31.JPG)