### PR TITLE
Add a feature to ignore grammar positions in morphemes.

### DIFF
--- a/morph/browser/extractMorphemes.py
+++ b/morph/browser/extractMorphemes.py
@@ -17,7 +17,7 @@ def per( st, n ):
     if notecfg is None: return st
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for f in notecfg['Fields']:
-        ms = getMorphemes(morphemizer, n[f], n.tags)
+        ms = getMorphemes(morphemizer, n[f], n.tags, cfg1('ignore grammar position'))
         loc = AnkiDeck(n.id, f, n[f], n.guid, mats)
         st['morphDb'].addMsL(ms, loc)
 

--- a/morph/browser/extractMorphemes.py
+++ b/morph/browser/extractMorphemes.py
@@ -15,9 +15,10 @@ def per( st, n ):
     mats = mw.col.db.list( 'select ivl from cards where nid = :nid', nid=n.id )
     notecfg = getFilter(n)
     if notecfg is None: return st
+    ignore_grammar_pos = cfg1('ignore grammar position')
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for f in notecfg['Fields']:
-        ms = getMorphemes(morphemizer, n[f], n.tags, cfg1('ignore grammar position'))
+        ms = getMorphemes(morphemizer, n[f], n.tags, ignore_grammar_pos)
         loc = AnkiDeck(n.id, f, n[f], n.guid, mats)
         st['morphDb'].addMsL(ms, loc)
 

--- a/morph/browser/viewMorphemes.py
+++ b/morph/browser/viewMorphemes.py
@@ -11,7 +11,7 @@ def per( st, n ):
     if notecfg is None: return st
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for f in notecfg['Fields']:
-        ms = getMorphemes(morphemizer, n[f], n.tags)
+        ms = getMorphemes(morphemizer, n[f], n.tags, cfg1('ignore grammar position'))
         st['morphemes'] += ms
     return st
 

--- a/morph/browser/viewMorphemes.py
+++ b/morph/browser/viewMorphemes.py
@@ -9,9 +9,10 @@ def pre( b ): return { 'morphemes': [] }
 def per( st, n ):
     notecfg = getFilter(n)
     if notecfg is None: return st
+    ignore_grammar_pos = cfg1('ignore grammar position')
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for f in notecfg['Fields']:
-        ms = getMorphemes(morphemizer, n[f], n.tags, cfg1('ignore grammar position'))
+        ms = getMorphemes(morphemizer, n[f], n.tags, ignore_grammar_pos)
         st['morphemes'] += ms
     return st
 

--- a/morph/config.py
+++ b/morph/config.py
@@ -22,6 +22,9 @@ default = {
     'threshold_seen': 1/86400.,     # this currently isn't used outside of create seen.db for your personal usage
     'text file import maturity':22, # when you import a file via Extract Morphemes from file, they are all given this maturity
 
+    # change morpheme parsing
+    'ignore grammar position': False, # if True, ignores morpheme grammar positions.  Delete your all.db if changing.
+
     # reviewer mode keybindings
     'browse same focus key': 'l',
     'set known and skip key': 'k',

--- a/morph/main.py
+++ b/morph/main.py
@@ -92,7 +92,7 @@ def mkAllDb( allDb=None ):
             loc = fidDb.get( ( nid, guid, fieldName ), None )
             if not loc:
                 loc = AnkiDeck( nid, fieldName, fieldValue, guid, mats )
-                ms = getMorphemes(morphemizer, fieldValue, ts)
+                ms = getMorphemes(morphemizer, fieldValue, ts, C('ignore grammar position'))
                 if ms: #TODO: this needed? should we change below too then?
                     locDb[ loc ] = ms
             else:
@@ -103,7 +103,7 @@ def mkAllDb( allDb=None ):
                 # field changed -> new loc, new morphs
                 elif loc.fieldValue != fieldValue:
                     newLoc = AnkiDeck( nid, fieldName, fieldValue, guid, mats )
-                    ms = getMorphemes(morphemizer, fieldValue, ts)
+                    ms = getMorphemes(morphemizer, fieldValue, ts, C('ignore grammar position'))
                     locDb.pop( loc )
                     locDb[ newLoc ] = ms
 

--- a/morph/main.py
+++ b/morph/main.py
@@ -61,6 +61,8 @@ def mkAllDb( allDb=None ):
     fidDb   = allDb.fidDb()
     locDb   = allDb.locDb( recalc=False )   # fidDb() already forces locDb recalc
 
+    ignore_grammar_pos = cfg1('ignore grammar position')
+
     mw.progress.update( label='Generating all.db data' )
     for i,( nid, mid, flds, guid, tags ) in enumerate( db.execute( 'select id, mid, flds, guid, tags from notes' ) ):
         if i % 500 == 0:    mw.progress.update( value=i )
@@ -92,7 +94,7 @@ def mkAllDb( allDb=None ):
             loc = fidDb.get( ( nid, guid, fieldName ), None )
             if not loc:
                 loc = AnkiDeck( nid, fieldName, fieldValue, guid, mats )
-                ms = getMorphemes(morphemizer, fieldValue, ts, C('ignore grammar position'))
+                ms = getMorphemes(morphemizer, fieldValue, ts, ignore_grammar_pos)
                 if ms: #TODO: this needed? should we change below too then?
                     locDb[ loc ] = ms
             else:
@@ -103,7 +105,7 @@ def mkAllDb( allDb=None ):
                 # field changed -> new loc, new morphs
                 elif loc.fieldValue != fieldValue:
                     newLoc = AnkiDeck( nid, fieldName, fieldValue, guid, mats )
-                    ms = getMorphemes(morphemizer, fieldValue, ts, C('ignore grammar position'))
+                    ms = getMorphemes(morphemizer, fieldValue, ts, ignore_grammar_pos)
                     locDb.pop( loc )
                     locDb[ newLoc ] = ms
 

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -57,7 +57,7 @@ class Morpheme:
 def ms2str( ms ): # [Morpheme] -> Str
     return '\n'.join( m.show() for m in ms )
 
-def getMorphemes(morphemizer, expression, note_tags=None):
+def getMorphemes(morphemizer, expression, note_tags=None, ignore_positions=False):
     if jcfg('Option_IgnoreBracketContents'):
         regex = r'\[[^\]]*\]'
         if re.search(regex, expression):
@@ -88,6 +88,14 @@ def getMorphemes(morphemizer, expression, note_tags=None):
 
 
     ms = morphemizer.getMorphemesFromExpr(expression)
+
+    if ignore_positions:
+        def removePositions(m):
+            m.pos = '---'
+            m.subPos = '---'
+            return m
+        ms = [ removePositions( m ) for m in ms ]
+
     return ms
 
 

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -32,30 +32,33 @@ class Morpheme:
         # values are created by "mecab" in the order of the parameters and then directly passed into this constructor
         # example of mecab output:    "歩く     歩い    動詞    自立      アルイ"
         # matches to:                 "base     infl    pos     subPos    read"
-        self.pos    = pos # type of morpheme detemined by mecab tool. for example: u'動詞' or u'助動詞', u'形容詞'
-        self.subPos = subPos
         self.read   = read
         self.base   = base
+        self.pos    = pos # type of morpheme detemined by mecab tool. for example: u'動詞' or u'助動詞', u'形容詞'
+        self.subPos = subPos
         self.inflected = inflected
 
     def __eq__( self, o ):
         if not isinstance( o, Morpheme ): return False
-        if self.pos != o.pos: return False
-        if self.subPos != o.subPos: return False
         if self.read != o.read: return False
         if self.base != o.base: return False
+        if self.pos != o.pos: return False
+        if self.subPos != o.subPos: return False
         #if self.inflected != o.inflected: return False
         return True
 
     def __hash__( self ):
         #return hash( (self.pos, self.subPos, self.read, self.base, self.inflected) )
-        return hash( (self.pos, self.subPos, self.read, self.base) )
+        return hash( (self.read, self.base, self.pos, self.subPos) )
 
     def show( self ): # str
         return '\t'.join([ self.base, self.pos, self.subPos, self.read ])
 
 def ms2str( ms ): # [Morpheme] -> Str
     return '\n'.join( m.show() for m in ms )
+
+def removePositions( m ):
+    return Morpheme(m.base, m.inflected, '', '', m.read)
 
 def getMorphemes(morphemizer, expression, note_tags=None, ignore_positions=False):
     if jcfg('Option_IgnoreBracketContents'):
@@ -90,10 +93,6 @@ def getMorphemes(morphemizer, expression, note_tags=None, ignore_positions=False
     ms = morphemizer.getMorphemesFromExpr(expression)
 
     if ignore_positions:
-        def removePositions(m):
-            m.pos = '---'
-            m.subPos = '---'
-            return m
         ms = [ removePositions( m ) for m in ms ]
 
     return ms


### PR DESCRIPTION
This is useful when using frequency lists or priority Dbs, where the
correct grammar positions may be unknown.