### PR TITLE
Fix ability to filter by multiple fields and tags

### DIFF
--- a/morph/preferencesDialog.py
+++ b/morph/preferencesDialog.py
@@ -238,8 +238,8 @@ class PreferencesDialog( QDialog ):
         if rowGui['modelComboBox'].currentIndex() == 0: filter['Type'] = None # no filter "All note types"
         else: filter['Type'] = rowGui['modelComboBox'].currentText()
 
-        filter['Tags'] =  [x for x in rowGui['tagsEntry'].text().split(',') if x]
-        filter['Fields'] = [x for x in rowGui['fieldsEntry'].text().split(',') if x]
+        filter['Tags'] =  [x for x in rowGui['tagsEntry'].text().split(', ') if x]
+        filter['Fields'] = [x for x in rowGui['fieldsEntry'].text().split(', ') if x]
 
         filter['Morphemizer'] = getAllMorphemizers()[rowGui['morphemizerComboBox'].currentIndex()].__class__.__name__
         filter['Modify'] = rowGui['modifyCheckBox'].checkState() != Qt.Unchecked


### PR DESCRIPTION
Differences in how the display was formatted and how the fields were parsed were causing errors, This PR fixes the bug.

The GUI code joined by ", " but the split code split by ","
```
rowGui['tagsEntry'] = QLineEdit(', '.join(data['Tags']))
rowGui['fieldsEntry'] = QLineEdit(', '.join(data['Fields']))
```
I created this PR in response to an issue created, but the issue was deleted for some reason... Here's a screenshot: https://gyazo.com/fac121d94f596c6251b321c9cdfad0a3