### PR TITLE
Prevent focus field from being erased when card becomes i+0

### DIFF
--- a/morph/main.py
+++ b/morph/main.py
@@ -257,7 +257,6 @@ def updateNotes( allDb ):
         # determine card type
         if N_m == 0:    # sentence comprehension card, m+0
             ts = ts + [ compTag ]
-            setField( mid, fs, jcfg('Field_FocusMorph'), '' )
         elif N_k == 1:  # new vocab card, k+1
             ts = ts + [ vocabTag ]
             setField( mid, fs, jcfg('Field_FocusMorph'), '%s' % focusMorph.base )


### PR DESCRIPTION
There is no utility to updating the field of an i+0 card. This PR alternative gets the best of both worlds - now, Morphman doesn't add anything to the focus field if the card is i+0, but if the card becomes i+0 over time on recalcs, the field will be left alone.