### PR TITLE
Morphemizer: Normalized form, grouping, and variations in DB.

### DIFF
--- a/morph/browser/extractMorphemes.py
+++ b/morph/browser/extractMorphemes.py
@@ -15,10 +15,9 @@ def per( st, n ):
     mats = mw.col.db.list( 'select ivl from cards where nid = :nid', nid=n.id )
     notecfg = getFilter(n)
     if notecfg is None: return st
-    ignore_grammar_pos = cfg1('ignore grammar position')
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for f in notecfg['Fields']:
-        ms = getMorphemes(morphemizer, n[f], n.tags, ignore_grammar_pos)
+        ms = getMorphemes(morphemizer, n[f], n.tags)
         loc = AnkiDeck(n.id, f, n[f], n.guid, mats)
         st['morphDb'].addMsL(ms, loc)
 

--- a/morph/browser/viewMorphemes.py
+++ b/morph/browser/viewMorphemes.py
@@ -9,10 +9,9 @@ def pre( b ): return { 'morphemes': [] }
 def per( st, n ):
     notecfg = getFilter(n)
     if notecfg is None: return st
-    ignore_grammar_pos = cfg1('ignore grammar position')
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for f in notecfg['Fields']:
-        ms = getMorphemes(morphemizer, n[f], n.tags, ignore_grammar_pos)
+        ms = getMorphemes(morphemizer, n[f], n.tags)
         st['morphemes'] += ms
     return st
 

--- a/morph/browser/viewMorphemes.py
+++ b/morph/browser/viewMorphemes.py
@@ -19,7 +19,7 @@ def post( st ):
     if len(st['morphemes']) == 0:
         infoMsg('----- No morphemes, check your filters -----')
         return
-    s = ms2str( st['morphemes'] )
+    s = ms2str( [(m, []) for m in st['morphemes']] )
     infoMsg( '----- All -----\n' + s )
 
 def runViewMorphemes():

--- a/morph/manager.py
+++ b/morph/manager.py
@@ -127,13 +127,13 @@ class MorphMan( QDialog ):
 
         # Display
         vbox.addSpacing(40)
-        self.col4Mode = QRadioButton( 'Results as 4col morpheme' )
-        self.col4Mode.setChecked( True )
-        self.col1Mode = QRadioButton( 'Results as 1col morpheme' )
-        self.col4Mode.clicked.connect(self.colModeButtonListener)
-        self.col1Mode.clicked.connect(self.colModeButtonListener)
-        vbox.addWidget( self.col4Mode )
-        vbox.addWidget( self.col1Mode )
+        self.col_all_Mode = QRadioButton( 'All result columns' )
+        self.col_all_Mode.setChecked( True )
+        self.col_one_Mode = QRadioButton( 'One result column' )
+        self.col_all_Mode.clicked.connect(self.colModeButtonListener)
+        self.col_one_Mode.clicked.connect(self.colModeButtonListener)
+        vbox.addWidget( self.col_all_Mode )
+        vbox.addWidget( self.col_one_Mode )
         self.morphDisplay = QTextEdit()
         self.analysisDisplay = QTextEdit()
 
@@ -180,7 +180,7 @@ class MorphMan( QDialog ):
         elif type == 'inter':   ms = aSet.intersection( bSet )
         elif type == 'union':   ms = aSet.union( bSet )
 
-        self.db.db = {}
+        self.db.clear()
         for m in ms:
             locs = set()
             if m in self.aDb.db: locs.update( self.aDb.db[m] )
@@ -216,10 +216,10 @@ class MorphMan( QDialog ):
                 return # User has not selected a db view yet
 
     def updateDisplay( self ):
-        if self.col4Mode.isChecked():
+        if self.col_all_Mode.isChecked():
             self.morphDisplay.setText( self.db.showMs() )
         else:
-            self.morphDisplay.setText( '\n'.join( [ m.base for m in self.db.db ] ) )
+            self.morphDisplay.setText( '\n'.join( sorted(list(set([ m.norm for m in self.db.db ]))) ) )
         self.analysisDisplay.setText( self.db.analyze2str() )
 
 def main():

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -44,7 +44,7 @@ class Morpheme:
     def __setstate__(self, d):
         """ Override default pickle __setstate__ to initialize missing defaults in old databases
         """
-        self.norm = d.get('norm', None)
+        self.norm = d['norm'] if 'norm' in d else d['base']
         self.base = d['base']
         self.inflected = d['inflected']
         self.read = d['read']

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -243,10 +243,7 @@ class MorphDb:
         if not os.path.exists( par ):
             os.makedirs( par )
         f = gzip.open( path, 'wb' )
-        db = {}
-        db['version'] = 2.0
-        db['db'] = self.db
-        pickle.dump( db, f, -1 )
+        pickle.dump( self.db, f, -1 )
         f.close()
 
     def load( self, path ): # FilePath -> m ()

--- a/morph/stats.py
+++ b/morph/stats.py
@@ -34,7 +34,8 @@ def updateStats( knownDb=None ):
     if knownDb is None:
         knownDb = MorphDb( cfg1('path_known'), ignoreErrors=True )
 
-    d['totalKnown'] = len( knownDb.db )
+    d['totalVariations'] = len( knownDb.db )
+    d['totalKnown'] = len( knownDb.groups )
 
     saveStats( d )
     mw.progress.finish()
@@ -44,7 +45,10 @@ def getStatsLink():
     d = loadStats()
     if not d: return ( 'K ???', '????' )
 
-    name = 'K %d' % d['totalKnown']
+    total_known = d.get('totalKnown', 0)
+    total_variations = d.get('totalVariations', total_known)
+
+    name = 'K %d V %d' % (total_known, total_variations)
     details = 'Total known morphs'
     return ( name, details )
 


### PR DESCRIPTION
This is a pretty large change which introduces a new Morpheme field,
adds morpheme grouping, and makes morph database loading more robust.

[Normal Form]
- Morphemes gain a new field (Morpheme.norm) which corresponds to
  the Normalized Form in the UniDic Japanese Dictionary.
- Other dictionaries continue to use the base dictionary form.
- Databases can automatically upgrade on load, and are now more robust
  at handling add-on updates that could previously cause old databases
  to throw exceptions during loading.

[Morph groups]
- The new K count corresponds to Morpheme Groups.
- These are morphemes that have the same .norm + .reading + .pos fields.
- The new V count corresponds to all Moprhmene Variations based on all
  fields.
- Morpheme groups are generated at runtime, so they don't affect the DB.
- Grouping also makes the 'ignore grammar position' feature cleaner by
  dropping the .pos field when grouping without the need to rebuild DBs.

[Fuzzy matching]
- Groups enable fuzzy matching for morphemes that correspond to the same
  morph families.
- E.g. if you know 写真 then しゃしん is also treated as known, but not
  vice-versa.

[Other]
- DB Manager now displays all the morph fields.
- DB Manager database lists are now sorted, and include frequency counts.