### PR TITLE
Morphemizer: Strip HTML before getting morphemes from fields.

### DIFF
--- a/morph/browser/extractMorphemes.py
+++ b/morph/browser/extractMorphemes.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
 import os
 from anki.hooks import addHook
+from anki.utils import stripHTML
 from ..morphemes import AnkiDeck, MorphDb, getMorphemes, ms2str
 from ..morphemizer import getMorphemizerByName
 from ..util import addBrowserNoteSelectionCmd, mw, getFilter, infoMsg, QFileDialog, cfg1
@@ -17,7 +18,7 @@ def per( st, n ):
     if notecfg is None: return st
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for f in notecfg['Fields']:
-        ms = getMorphemes(morphemizer, n[f], n.tags)
+        ms = getMorphemes(morphemizer, stripHTML(n[f]), n.tags)
         loc = AnkiDeck(n.id, f, n[f], n.guid, mats)
         st['morphDb'].addMsL(ms, loc)
 

--- a/morph/browser/massTagger.py
+++ b/morph/browser/massTagger.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
 from aqt.utils import tooltip
 from anki.hooks import addHook
+from anki.utils import stripHTML
 from ..morphemes import getMorphemes, MorphDb
 from ..morphemizer import getMorphemizerByName
 from ..util import addBrowserNoteSelectionCmd, getFilter, infoMsg, QInputDialog, QFileDialog, QLineEdit, cfg1
@@ -26,7 +27,7 @@ def per( st, n ): # :: State -> Note -> State
     if notecfg is None: return st
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for field in notecfg['Fields']:
-        for m in getMorphemes(morphemizer, n[ field ], n.tags):
+        for m in getMorphemes(morphemizer, stripHTML(n[ field ]), n.tags):
             if m in st['db'].db:
                 n.addTag(st['tags'])
                 break

--- a/morph/browser/viewMorphemes.py
+++ b/morph/browser/viewMorphemes.py
@@ -1,5 +1,6 @@
 #-*- coding: utf-8 -*-
 from anki.hooks import addHook
+from anki.utils import stripHTML
 from ..morphemes import getMorphemes, ms2str
 from ..morphemizer import getMorphemizerByName
 from ..util import addBrowserNoteSelectionCmd, getFilter, infoMsg, cfg1
@@ -11,7 +12,7 @@ def per( st, n ):
     if notecfg is None: return st
     morphemizer = getMorphemizerByName(notecfg['Morphemizer'])
     for f in notecfg['Fields']:
-        ms = getMorphemes(morphemizer, n[f], n.tags)
+        ms = getMorphemes(morphemizer, stripHTML(n[f]), n.tags)
         st['morphemes'] += ms
     return st
 


### PR DESCRIPTION
HTML gets stripped from fields when updating the database.  Do the
same when extracting or viewing morphemes elsewhere.